### PR TITLE
[workaround] gsl-lite warning C4875: a non-string literal argument to…

### DIFF
--- a/support/unit/CMakeLists.txt
+++ b/support/unit/CMakeLists.txt
@@ -43,8 +43,9 @@ FetchContent_Declare(
   SOURCE_SUBDIR "src" FIND_PACKAGE_ARGS NAMES mp-units)
 FetchContent_MakeAvailable(mp-units)
 
-target_compile_options(mp-units INTERFACE $<IF:$<CXX_COMPILER_ID:MSVC>, ,
-                                          -Wno-double-promotion -Wno-undef>)
+target_compile_options(
+  mp-units INTERFACE $<IF:$<CXX_COMPILER_ID:MSVC>, "/wd4875",
+                     "-Wno-double-promotion" "-Wno-undef">)
 
 add_library(typed_linear_algebra_unit INTERFACE)
 target_sources(


### PR DESCRIPTION
… [[gsl::suppress]] is deprecated and will be removed in a future release

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/FrancoisCarouge/TypedLinearAlgebra/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in the following license file, and represent that you
have the right to do so:
https://github.com/FrancoisCarouge/TypedLinearAlgebra/blob/master/LICENSE.txt
-->
