### PR TITLE
[support] return workaround: use tip of repository for mp-units

### DIFF
--- a/support/unit/CMakeLists.txt
+++ b/support/unit/CMakeLists.txt
@@ -39,7 +39,7 @@ FetchContent_MakeAvailable(gsl-lite)
 FetchContent_Declare(
   mp-units
   GIT_REPOSITORY "https://github.com/mpusz/mp-units"
-  GIT_TAG 779d78fce93f8b8f587684c7482ac40b3fdd3a7e
+  GIT_SHALLOW TRUE
   SOURCE_SUBDIR "src" FIND_PACKAGE_ARGS NAMES mp-units)
 FetchContent_MakeAvailable(mp-units)
 


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/FrancoisCarouge/TypedLinearAlgebra/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in the following license file, and represent that you
have the right to do so:
https://github.com/FrancoisCarouge/TypedLinearAlgebra/blob/master/LICENSE.txt
-->
