### PR TITLE
[support] Restore default/no options for mp-units

### DIFF
--- a/support/unit/CMakeLists.txt
+++ b/support/unit/CMakeLists.txt
@@ -36,11 +36,6 @@ FetchContent_Declare(
   FIND_PACKAGE_ARGS NAMES gsl-lite)
 FetchContent_MakeAvailable(gsl-lite)
 
-set(MP_UNITS_LIB_FORMAT_SUPPORTED ON)
-set(MP_UNITS_API_FREESTANDING OFF)
-set(MP_UNITS_API_STD_FORMAT ON)
-set(MP_UNITS_BUILD_INSTALL OFF)
-
 FetchContent_Declare(
   mp-units
   GIT_REPOSITORY "https://github.com/mpusz/mp-units"


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/FrancoisCarouge/TypedLinearAlgebra/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in the following license file, and represent that you
have the right to do so:
https://github.com/FrancoisCarouge/TypedLinearAlgebra/blob/master/LICENSE.txt
-->

It is preferable for end-user ergonomics to have automatic defaults.